### PR TITLE
Update payment meta methods, storage

### DIFF
--- a/edd-campaign-tracker.php
+++ b/edd-campaign-tracker.php
@@ -82,6 +82,7 @@ class EDD_Campaign_Tracker {
 		require_once EDD_CAMPAIGN_TRACKER_DIR . '/includes/payment-screen.php';
 		require_once EDD_CAMPAIGN_TRACKER_DIR . '/includes/email-tag.php';
 		require_once EDD_CAMPAIGN_TRACKER_DIR . '/includes/reports.php';
+		require_once EDD_CAMPAIGN_TRACKER_DIR . '/includes/updates.php';
 	}
 
 	/**

--- a/includes/campaign-logger.php
+++ b/includes/campaign-logger.php
@@ -64,7 +64,7 @@ class EDDCT_Campaign_Logger {
 			$campaign_info = $payment_meta['eddct_campaign'];
 
 			if ( isset( $campaign_info['name'] ) ) {
-				update_post_meta( $payment_id, '_eddct_campaign_name', $campaign_info['name'] );
+				edd_update_payment_meta( $payment_id, '_eddct_campaign_name', $campaign_info['name'] );
 			}
 		}
 	}

--- a/includes/campaign-logger.php
+++ b/includes/campaign-logger.php
@@ -28,7 +28,7 @@ class EDDCT_Campaign_Logger {
 
 		$campaign_info = self::get_campaign_info();
 		if ( ! empty( $campaign_info ) ) {
-			$payment_meta['campaign_info'] = $campaign_info;
+			$payment_meta['eddct_campaign'] = $campaign_info;
 		}
 
 		return $payment_meta;
@@ -45,7 +45,7 @@ class EDDCT_Campaign_Logger {
 		$campaign_info = self::get_campaign_info();
 
 		if ( ! empty( $campaign_info ) ) {
-			edd_add_order_meta( $order_id, 'campaign_info', $campaign_info );
+			edd_add_order_meta( $order_id, 'eddct_campaign', $campaign_info );
 		}
 	}
 

--- a/includes/campaign-logger.php
+++ b/includes/campaign-logger.php
@@ -38,7 +38,7 @@ class EDDCT_Campaign_Logger {
 	 * Adds the campaign info to the order meta in EDD 3.0.
 	 *
 	 * @since 1.0.2
-	 * @param int $order_id
+	 * @param int $order_id The order ID.
 	 * @return void
 	 */
 	public static function add_campaign_order_meta( $order_id ) {

--- a/includes/payment-screen.php
+++ b/includes/payment-screen.php
@@ -80,7 +80,7 @@ class EDDCT_Payment_Screen {
 		}
 
 		if ( ! $campaign_info ) {
-			return __( 'No campaign information available', 'edd-campaign-tracker' );
+			return __( 'No campaign information available.', 'edd-campaign-tracker' );
 		}
 		ob_start();
 		?>

--- a/includes/payment-screen.php
+++ b/includes/payment-screen.php
@@ -56,29 +56,7 @@ class EDDCT_Payment_Screen {
 			return false;
 		}
 
-		$campaign_info = false;
-		if ( function_exists( 'edd_get_order_meta' ) ) {
-			$campaign_info = edd_get_order_meta( $payment_id, 'eddct_campaign', true );
-		}
-		if ( ! $campaign_info ) {
-			$payment_meta = edd_get_payment_meta( $payment_id );
-			if ( ! empty( $payment_meta['eddct_campaign'] ) ) {
-				$campaign_info = $payment_meta['eddct_campaign'];
-			}
-			// In EDD 3.0, if this metadata exists, it was not migrated, so go ahead and migrate it now.
-			if ( $campaign_info && function_exists( 'edd_add_order_meta' ) ) {
-				edd_add_order_meta( $payment_id, 'eddct_campaign', $campaign_info );
-
-				// Update the remaining payment meta, or delete if nothing is left.
-				unset( $payment_meta['eddct_campaign'] );
-				if ( empty( $payment_meta ) ) {
-					edd_delete_order_meta( $payment_id, 'payment_meta' );
-				} else {
-					edd_update_order_meta( $payment_id, 'payment_meta', $payment_meta );
-				}
-			}
-		}
-
+		$campaign_info = self::get_campaign_info( $payment_id );
 		if ( ! $campaign_info ) {
 			return __( 'No campaign information available.', 'edd-campaign-tracker' );
 		}
@@ -200,6 +178,40 @@ class EDDCT_Payment_Screen {
 		}
 
 		return $where;
+	}
+
+	/**
+	 * Gets the order campaign information.
+	 *
+	 * @since 1.0.2
+	 * @param  int $payment_id The order/payment ID.
+	 * @return array|false     The campaign information if it exists; false if it does not.
+	 */
+	private static function get_campaign_info( $payment_id ) {
+		$campaign_info = false;
+		if ( function_exists( 'edd_get_order_meta' ) ) {
+			$campaign_info = edd_get_order_meta( $payment_id, 'eddct_campaign', true );
+		}
+		if ( ! $campaign_info ) {
+			$payment_meta = edd_get_payment_meta( $payment_id );
+			if ( ! empty( $payment_meta['eddct_campaign'] ) ) {
+				$campaign_info = $payment_meta['eddct_campaign'];
+			}
+			// In EDD 3.0, if this metadata exists, it was not migrated, so go ahead and migrate it now.
+			if ( $campaign_info && function_exists( 'edd_add_order_meta' ) ) {
+				edd_add_order_meta( $payment_id, 'eddct_campaign', $campaign_info );
+
+				// Update the remaining payment meta, or delete if nothing is left.
+				unset( $payment_meta['eddct_campaign'] );
+				if ( empty( $payment_meta ) ) {
+					edd_delete_order_meta( $payment_id, 'payment_meta' );
+				} else {
+					edd_update_order_meta( $payment_id, 'payment_meta', $payment_meta );
+				}
+			}
+		}
+
+		return $campaign_info;
 	}
 }
 

--- a/includes/payment-screen.php
+++ b/includes/payment-screen.php
@@ -111,14 +111,12 @@ class EDDCT_Payment_Screen {
 	 * @return string              Value for the column
 	 */
 	public static function render_campaign_column( $value, $payment_id, $column_name ) {
-		if ( 'campaign' == $column_name ) {
-			$payment_meta = edd_get_payment_meta( $payment_id );
-			if ( isset( $payment_meta['eddct_campaign'] ) ) {
-				$campaign_info = $payment_meta['eddct_campaign'];
+		if ( 'campaign' === $column_name ) {
+			$value         = __( 'N/A', 'edd-campaign-tracker' );
+			$campaign_info = self::get_campaign_info( $payment_id );
+			if ( ! empty( $campaign_info['name'] ) ) {
 				$display_name = $campaign_info['name'];
-				$value = '<a href="' . esc_url( add_query_arg( array( 'campaign' => urlencode( $display_name ), 'paged' => false ) ) ) . '">' . $display_name . '</a>';
-			} else {
-				$value = __( 'N/A', 'edd-campaign-tracker' );
+				$value        = '<a href="' . esc_url( add_query_arg( array( 'campaign' => urlencode( $display_name ), 'paged' => false ) ) ) . '">' . esc_html( $display_name ) . '</a>';
 			}
 		}
 		return $value;

--- a/includes/updates.php
+++ b/includes/updates.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * During the EDD 3.0 migration, copies the user history from the old post metadata
+ * to the new order meta table.
+ *
+ * If the user history is the only thing in the `payment_meta`, delete that metadata.
+ * If anything else is left in the metadata, remove just the user history and update the order meta.
+ *
+ * @since 1.6.2
+ * @param int   $order_id      The new order ID.
+ * @param array $payment_meta  The original payment meta.
+ * @param array $name          The original post meta.
+ * @return void
+ */
+function eddct_30_migration( $order_id, $payment_meta, $meta ) {
+	$campaign_info = ! empty( $payment_meta['eddct_campaign'] ) ? $payment_meta['eddct_campaign'] : false;
+	if ( ! $campaign_info ) {
+		return;
+	}
+
+	edd_add_order_meta( $order_id, 'eddct_campaign', $campaign_info );
+	$migrated_meta = edd_get_order_meta( $order_id, 'payment_meta', true );
+	if ( is_array( $migrated_meta ) && ! empty( $migrated_meta ) ) {
+		unset( $migrated_meta['eddct_campaign'] );
+	}
+	if ( empty( $migrated_meta ) ) {
+		edd_delete_order_meta( $order_id, 'payment_meta' );
+	} else {
+		edd_update_order_meta( $order_id, 'payment_meta', $migrated_meta );
+	}
+}
+add_action( 'edd_30_migrate_order', 'eddct_30_migration', 10, 3 );


### PR DESCRIPTION
Fixes #11 

Proposed Changes:
1. Add an EDD 3.0 order meta function to store campaign information.
2. Update the campaign info rendering method to retrieve 3.0 order metadata and convert old metadata if it exists.
3. Add a migration function for sites updating to EDD 3.0 to automatically move payment meta to new order meta. (pending)